### PR TITLE
Fix package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-        ".": "./lib"
+        ".": "./lib/index.js"
     },
     "scripts": {
         "clean": "rimraf bundle lib",


### PR DESCRIPTION
I was running into some problems using this package with svelte kit/vite when building for production. The root of my problem seems to be that the ECMAScript module loader does not support directories/folders as modules. See https://nodejs.org/api/packages.html.

Also, this might be related to #89.

